### PR TITLE
Preserve whitespace in Ruby AST representation 

### DIFF
--- a/app/views/home.slim
+++ b/app/views/home.slim
@@ -49,7 +49,8 @@ form
       .card.ruby-ast.shadow
         .card-body
           h4.card-title Ruby AST
-          #ruby_ast
+          pre style=("white-space: pre-wrap;")
+            code#ruby_ast
 
 
 .quick-reference.py-3.small


### PR DESCRIPTION
Using `<pre><code>` causes [Bootstrap to style the AST as code][bootstrap-code-block], using a monospace font and preserving whitespace.

Applying `white-space: pre-wrap` causes the text to wrap if it is too wide to fit in the element (as opposed to making the element wider or overflowing).

[bootstrap-code-block]: https://getbootstrap.com/docs/4.5/content/code/#code-blocks

I haven't been able to try this out locally, but I've tried editing the HTML in production and this produces a decent result.

Before|After
-|-
<img width="368" alt="image" src="https://user-images.githubusercontent.com/8219340/159370699-74e9b131-b9c6-4dcc-ab96-a03466cee759.png">|<img width="381" alt="image" src="https://user-images.githubusercontent.com/8219340/159370586-d8615ecd-6110-4767-a54c-3c62d59d12dd.png">


Tentatively closes #2