### PR TITLE
Make `bundle exec rake serve` work out-of-the-box

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -5,7 +5,7 @@ source 'https://rubygems.org'
 # Specify your gem's dependencies in np.gemspec
 gemspec
 
-gem 'webrick'
+gem 'rackup', '~> 2.0'
 gem 'rake', '~> 12.0'
 gem 'rspec', '~> 3.0'
 

--- a/Rakefile
+++ b/Rakefile
@@ -7,7 +7,7 @@ RSpec::Core::RakeTask.new(:spec)
 
 task default: :spec
 
-PARCEL_OPTIONS = 'assets/index.* --global App --public-url /assets'
+PARCEL_OPTIONS = 'assets/index.* --public-url /assets'
 
 desc 'Start local server'
 task :serve do

--- a/Rakefile
+++ b/Rakefile
@@ -7,7 +7,7 @@ RSpec::Core::RakeTask.new(:spec)
 
 task default: :spec
 
-PARCEL_OPTIONS = 'assets/index.* --public-url /assets'
+PARCEL_OPTIONS = 'assets/index.* --public-url /assets --dist-dir dist'
 
 desc 'Start local server'
 task :serve do

--- a/app/assets/editors.js
+++ b/app/assets/editors.js
@@ -1,3 +1,4 @@
+import App from './app'
 import CodeMirror from 'codemirror/lib/codemirror'
 
 class CodeMirrorEditor {

--- a/app/assets/index.js
+++ b/app/assets/index.js
@@ -6,4 +6,7 @@ import 'bootstrap'
 
 import App from './app'
 
-module.exports = App
+document.addEventListener('DOMContentLoaded', () => {
+  const app = new App(document.querySelector('form'))
+  window.app = app;
+})

--- a/app/assets/index.sass
+++ b/app/assets/index.sass
@@ -1,14 +1,14 @@
-@import "codemirror/lib/codemirror.css"
+@import "../../node_modules/codemirror/lib/codemirror.css"
 
 
-@import "@fortawesome/fontawesome-free/css/all.css"
+@import "../../node_modules/@fortawesome/fontawesome-free/css/all.css"
 
-@import "../node_modules/bootswatch/dist/slate/variables"
+@import "../../node_modules/bootswatch/dist/slate/variables"
 $grid-columns: 24 !default
-@import "../node_modules/bootstrap/scss/bootstrap"
-@import "../node_modules/bootswatch/dist/slate/_bootswatch"
+@import "../../node_modules/bootstrap/scss/bootstrap"
+@import "../../node_modules/bootswatch/dist/slate/_bootswatch"
 
-@import "../node_modules/codemirror/theme/ambiance"
+@import "../../node_modules/codemirror/theme/ambiance"
 
 @import "sticky_footer"
 

--- a/app/views/home.slim
+++ b/app/views/home.slim
@@ -1,9 +1,3 @@
-javascript:
-  app = null
-  document.addEventListener('DOMContentLoaded', () => {
-    app = new App(document.querySelector('form'))
-  })
-
 h2 NodePattern Debugger
 
 form
@@ -29,7 +23,7 @@ form
       .actions.mt-3 align="right"
         .prompt.make-permalink.invisible style="float: left"
           | Current location set!
-        button.btn.btn-outline-secondary.btn-sm type="button" onclick="app.makePermalink()"
+        button.btn.btn-outline-secondary.btn-sm type="button" onclick="app.ui.makePermalink()"
           | Make Permalink
 
   .row
@@ -66,4 +60,3 @@ form
             = example
         .col.summary
           = summary
-

--- a/np.gemspec
+++ b/np.gemspec
@@ -29,7 +29,7 @@ Gem::Specification.new do |spec|
 
   spec.add_runtime_dependency 'rubocop-ast', '>= 0.7.0'
   spec.add_runtime_dependency 'require_relative_dir'
-  spec.add_runtime_dependency 'sinatra'
+  spec.add_runtime_dependency 'sinatra', "~> 4.0"
   spec.add_runtime_dependency 'sinatra-contrib'
   spec.add_runtime_dependency 'slim'
   spec.add_runtime_dependency 'faye-websocket'

--- a/package-lock.json
+++ b/package-lock.json
@@ -19,6 +19,7 @@
       },
       "devDependencies": {
         "@babel/core": "^7.11.6",
+        "@parcel/transformer-sass": "^2.9.3",
         "sass": "^1.26.10"
       }
     },
@@ -2077,6 +2078,26 @@
         "url": "https://opencollective.com/parcel"
       }
     },
+    "node_modules/@parcel/transformer-sass": {
+      "version": "2.9.3",
+      "resolved": "https://registry.npmjs.org/@parcel/transformer-sass/-/transformer-sass-2.9.3.tgz",
+      "integrity": "sha512-i9abj9bKg3xCHghJyTM3rUVxIEn9n1Rl+DFdpyNAD8VZ52COfOshFDQOWNuhU1hEnJOFYCjnfcO0HRTsg3dWmg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@parcel/plugin": "2.9.3",
+        "@parcel/source-map": "^2.1.1",
+        "sass": "^1.38.0"
+      },
+      "engines": {
+        "node": ">= 12.0.0",
+        "parcel": "^2.9.3"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
     "node_modules/@parcel/transformer-svg": {
       "version": "2.9.3",
       "resolved": "https://registry.npmjs.org/@parcel/transformer-svg/-/transformer-svg-2.9.3.tgz",
@@ -2743,6 +2764,7 @@
           "url": "https://opencollective.com/bootstrap"
         }
       ],
+      "license": "MIT",
       "peerDependencies": {
         "jquery": "1.9.1 - 3",
         "popper.js": "^1.16.1"

--- a/package.json
+++ b/package.json
@@ -2,7 +2,6 @@
   "name": "np",
   "version": "0.0.1",
   "description": "Ruby NodePattern Debugger",
-  "main": "index.js",
   "repository": "https://github.com/marcandre/np",
   "author": "Marc-Andre Lafortune",
   "license": "MIT",
@@ -18,6 +17,7 @@
   },
   "devDependencies": {
     "@babel/core": "^7.11.6",
+    "@parcel/transformer-sass": "^2.9.3",
     "sass": "^1.26.10"
   }
 }


### PR DESCRIPTION
I wanted to do a simple styling fix but ended up having to deal with the javascript ecosystem :face_exhaling: 

There were a few things wrong, not sure why parcel especially made trouble. It's locked to a specific version in `package.lock`.

See individual commits for details. Just a warning, I don't know how this is deployed and if it is compatible with that. You can take this PR as a building block and fix things up yourself if you prefer.