### PR TITLE
Update to bootstrap 5

### DIFF
--- a/app/assets/app.sass
+++ b/app/assets/app.sass
@@ -68,3 +68,7 @@
   fill: #1d2022
   color: #32383e
 
+a
+  text-decoration: none
+  &:hover
+    text-decoration: underline

--- a/app/views/footer.slim
+++ b/app/views/footer.slim
@@ -5,11 +5,11 @@
       li.list-inline-item
         a href="https://github.com/sponsors/marcandre"
           | @marcandre
-    ul.list-inline.col.text-right
+    ul.list-inline.col.text-end
       li.list-inline-item Based on:
       li.list-inline-item
         a href="https://github.com/rubocop-hq/rubocop-ast" RuboCop/AST
-      li.list-inline-item.ml-3 Kudos to:
+      li.list-inline-item.ms-3 Kudos to:
       li.list-inline-item
         a href="https://github.com/whitequark/parser" parser
       li.list-inline-item •

--- a/app/views/home.slim
+++ b/app/views/home.slim
@@ -3,7 +3,7 @@ h2 NodePattern Debugger
 form
   .row.mb-3
     .col-16
-      .card.pattern.shadow
+      .card.pattern.shadow.pb-1
         label.card-body.pb-1 for="pattern"
           h4.card-title Pattern
           .resize-frame
@@ -34,7 +34,7 @@ form
           .resize-frame
             textarea name="ruby" rows="3" cols="40"
               = @ruby
-          ul.legend.list-group.list-group-horizontal
+          ul.legend.list-group.list-group-horizontal.text-muted
             li.list-group-item.matched match
             li.list-group-item.also-matched additional matches
             li.list-group-item.not-matched closest non-match
@@ -50,7 +50,7 @@ form
 .quick-reference.py-3.small
   h4
     | Quick
-    a.ml-1 href="https://docs.rubocop.org/rubocop-ast/node_pattern.html" reference
+    a.ms-1 href="https://docs.rubocop.org/rubocop-ast/node_pattern.html" reference
   - columns = DOCS.each_slice((DOCS.size + 1) / 2).to_a
   - columns.shift.zip(*columns) do |docs|
     .row

--- a/app/views/layout.slim
+++ b/app/views/layout.slim
@@ -9,11 +9,6 @@ html lang="en"
 
     link rel="stylesheet" type="text/css" href="assets/index.css"
   body
-    /! Optional JavaScript
-    /! jQuery first, then Popper.js, then Bootstrap JS
-    script crossorigin="anonymous" integrity="sha384-DfXdz2htPH0lsSSs5nCTpuj/zy4C+OGpamoFVy38MVBnE+IbbVYUew+OrCXaRkfj" src="https://code.jquery.com/jquery-3.5.1.slim.min.js"
-    script crossorigin="anonymous" integrity="sha384-9/reFTGAW83EW2RDu2S0VKaIzap3H66lZH81PoYlFhbGU+6BZp6G7niu735Sk7lN" src="https://cdn.jsdelivr.net/npm/popper.js@1.16.1/dist/umd/popper.min.js"
-
     script src="assets/index.js"
 
     == erb :github_link

--- a/package-lock.json
+++ b/package-lock.json
@@ -10,12 +10,10 @@
       "license": "MIT",
       "dependencies": {
         "@fortawesome/fontawesome-free": "^5.14.0",
-        "bootstrap": "^4.5.2",
-        "bootswatch": "^4.5.2",
+        "bootstrap": "^5.3.3",
+        "bootswatch": "^5.3.3",
         "codemirror": "^5.57.0",
-        "jquery": "^3.5.1",
-        "parcel": "^2.9.3",
-        "popper.js": "^1.16.1"
+        "parcel": "^2.9.3"
       },
       "devDependencies": {
         "@babel/core": "^7.11.6",
@@ -2495,6 +2493,17 @@
         "@parcel/core": "^2.9.3"
       }
     },
+    "node_modules/@popperjs/core": {
+      "version": "2.11.8",
+      "resolved": "https://registry.npmjs.org/@popperjs/core/-/core-2.11.8.tgz",
+      "integrity": "sha512-P1st0aksCrn9sGZhp8GMYwBnQsbvAWsZAX44oXNNvLHGqAOcoVxmjZiohstwQ7SqKnbR47akdNi+uleWD8+g6A==",
+      "license": "MIT",
+      "peer": true,
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/popperjs"
+      }
+    },
     "node_modules/@swc/core": {
       "version": "1.3.74",
       "resolved": "https://registry.npmjs.org/@swc/core/-/core-1.3.74.tgz",
@@ -2751,9 +2760,9 @@
       "integrity": "sha512-JZOSA7Mo9sNGB8+UjSgzdLtokWAky1zbztM3WRLCbZ70/3cTANmQmOdR7y2g+J0e2WXywy1yS468tY+IruqEww=="
     },
     "node_modules/bootstrap": {
-      "version": "4.6.2",
-      "resolved": "https://registry.npmjs.org/bootstrap/-/bootstrap-4.6.2.tgz",
-      "integrity": "sha512-51Bbp/Uxr9aTuy6ca/8FbFloBUJZLHwnhTcnjIeRn2suQWsWzcuJhGjKDB5eppVte/8oCdOL3VuwxvZDUggwGQ==",
+      "version": "5.3.3",
+      "resolved": "https://registry.npmjs.org/bootstrap/-/bootstrap-5.3.3.tgz",
+      "integrity": "sha512-8HLCdWgyoMguSO9o+aH+iuZ+aht+mzW0u3HIMzVu7Srrpv7EBBxTnrFlSCskwdY1+EOFQSm7uMJhNQHkdPcmjg==",
       "funding": [
         {
           "type": "github",
@@ -2766,14 +2775,14 @@
       ],
       "license": "MIT",
       "peerDependencies": {
-        "jquery": "1.9.1 - 3",
-        "popper.js": "^1.16.1"
+        "@popperjs/core": "^2.11.8"
       }
     },
     "node_modules/bootswatch": {
-      "version": "4.6.2",
-      "resolved": "https://registry.npmjs.org/bootswatch/-/bootswatch-4.6.2.tgz",
-      "integrity": "sha512-pHOS3d2yM/x9Y7/zwVzfGhGIIBdIa/rPwipghh756PaSNJS3ott/29d9uehakgze3pDvbH4FoQVjbho8wsLm6A=="
+      "version": "5.3.3",
+      "resolved": "https://registry.npmjs.org/bootswatch/-/bootswatch-5.3.3.tgz",
+      "integrity": "sha512-cJLhobnZsVCelU7zdH/L7wpcXAyUoTX4/5l2dWQ0JXgaVK80BdTQNU/ImWwoyIGBeyms4iQDAdNtOfPQZf0Atg==",
+      "license": "MIT"
     },
     "node_modules/braces": {
       "version": "3.0.2",
@@ -3423,11 +3432,6 @@
         "node": ">=0.12.0"
       }
     },
-    "node_modules/jquery": {
-      "version": "3.6.4",
-      "resolved": "https://registry.npmjs.org/jquery/-/jquery-3.6.4.tgz",
-      "integrity": "sha512-v28EW9DWDFpzcD9O5iyJXg3R3+q+mET5JhnjJzQUZMHOv67bpSIHq81GEYpPNZHG+XXHsfSme3nxp/hndKEcsQ=="
-    },
     "node_modules/js-tokens": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-4.0.0.tgz",
@@ -3960,16 +3964,6 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/jonschlinkert"
-      }
-    },
-    "node_modules/popper.js": {
-      "version": "1.16.1",
-      "resolved": "https://registry.npmjs.org/popper.js/-/popper.js-1.16.1.tgz",
-      "integrity": "sha512-Wb4p1J4zyFTbM+u6WuO4XstYx4Ky9Cewe4DWrel7B0w6VVICvPwdOpotjzcf6eD8TsckVnIMNONQyPIUFOUbCQ==",
-      "deprecated": "You can find the new Popper v2 at @popperjs/core, this package is dedicated to the legacy v1",
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/popperjs"
       }
     },
     "node_modules/postcss-value-parser": {

--- a/package.json
+++ b/package.json
@@ -8,12 +8,10 @@
   "private": false,
   "dependencies": {
     "@fortawesome/fontawesome-free": "^5.14.0",
-    "bootstrap": "^4.5.2",
-    "bootswatch": "^4.5.2",
+    "bootstrap": "^5.3.3",
+    "bootswatch": "^5.3.3",
     "codemirror": "^5.57.0",
-    "jquery": "^3.5.1",
-    "parcel": "^2.9.3",
-    "popper.js": "^1.16.1"
+    "parcel": "^2.9.3"
   },
   "devDependencies": {
     "@babel/core": "^7.11.6",


### PR DESCRIPTION
* jquery and popper are optional (already so in v4). It requires js for advances stuff like carousels only. I expected `peerDependencies` warnings from npm but it looks like those may not be a thing anymore.
* Revert link styling to v4
* Update some css class names

There are some differences (font size, width, etc.) but I would not say it looks worse. The slightly larger text for the quick reference in particular just looks better I think.

Live:
![image](https://github.com/user-attachments/assets/f5f01c44-06f8-4909-8dc4-8ecb200a96d7)

PR:
![image](https://github.com/user-attachments/assets/3ff5e862-816c-490b-9a9f-465e50c3bfa3)
