### PR TITLE
Update rubocop github link to point to new organization name

### DIFF
--- a/app/views/footer.slim
+++ b/app/views/footer.slim
@@ -8,7 +8,7 @@
     ul.list-inline.col.text-end
       li.list-inline-item Based on:
       li.list-inline-item
-        a href="https://github.com/rubocop-hq/rubocop-ast" RuboCop/AST
+        a href="https://github.com/rubocop/rubocop-ast" RuboCop/AST
         == " v#{Gem.loaded_specs["rubocop-ast"].version}"
       li.list-inline-item.ms-3 Using Ruby v#{RUBY_VERSION}
       li.list-inline-item.ms-3 Kudos to:


### PR DESCRIPTION
Small update to the link in the footer to use the `rubocop` github organization instead of `rubocop-hq`. Not a huge deal as the link as is redirects, but it'll make the "proper" link show up in a browser status bar at least!