### PR TITLE
Add rubocop-ast and ruby versions to footer

### DIFF
--- a/app/views/footer.slim
+++ b/app/views/footer.slim
@@ -9,6 +9,8 @@
       li.list-inline-item Based on:
       li.list-inline-item
         a href="https://github.com/rubocop-hq/rubocop-ast" RuboCop/AST
+        == " v#{Gem.loaded_specs["rubocop-ast"].version}"
+      li.list-inline-item.ms-3 Using Ruby v#{RUBY_VERSION}
       li.list-inline-item.ms-3 Kudos to:
       li.list-inline-item
         a href="https://github.com/whitequark/parser" parser


### PR DESCRIPTION
Before the recent updates to this repo, the heroku app doesn't seem to have been deployed in a while, and was not supporting all the features that rubocop-ast does, which means when I was trying to test some patterns with it, some node types were not present.

With that in mind, I wanted to propose adding ruby and rubocop-ast version #s to the footer so we can see at a glance what version is being used on the heroku app.

<img width="1326" alt="image" src="https://github.com/user-attachments/assets/a541792c-6493-4ea3-9773-534317888ba0">
